### PR TITLE
Day 3 materials

### DIFF
--- a/ParamTools/ParamToolsDemo.ipynb
+++ b/ParamTools/ParamToolsDemo.ipynb
@@ -1,0 +1,466 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Handling Model Parameters with ParamTools\n",
+    "### [Jason DeBacker](https://jasondebacker.com), October 2024\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "When working with structural models, how do we handle parameter inputs?\n",
+    "\n",
+    "* Worst case: hard-coded parameters in the model code\n",
+    "* Better: parameter values declared near the top of the main execution script\n",
+    "* Best: parameter values stored in a separate file and read in at the beginning of the script\n",
+    "\n",
+    "But even with the best approach, we can still run into some issues;\n",
+    "* How do we structure metadata?\n",
+    "* How do we pass parameters around within the model?\n",
+    "* How do we handle parameter updates?\n",
+    "* How do we handle parameter validation?\n",
+    "* What do we do with time varying parameters?\n",
+    "* What is parameters are indexed to change over time?\n",
+    "\n",
+    "In this notebook, we'll introduce [`ParamTools`](https://github.com/PSLmodels/ParamTools), a Python package that helps us handle these issues.  We'll use `ParamTools` to build a simple parameters object and show how it can help us manage parameters in a more efficient and robust way.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import paramtools\n",
+    "import taxcalc\n",
+    "import ogcore\n",
+    "import copy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Structuring Parameter Metadata\n",
+    "\n",
+    "The JSON format is a human-readable, flexible format for storing hierarchical data.  We can use JSON to store metadata about our parameters.  For example, we can store information about the parameter's name, its type, its value, its description, and its constraints.  Here's an example of how we might structure metadata for a parameter:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "    \"title\": \"Parameter Metadata\",\n",
+    "    \"type\": \"object\",\n",
+    "    \"properties\": {\n",
+    "        \"param_name\": {\n",
+    "            \"title\": \"Parameter Name\",\n",
+    "            \"type\": \"float\",\n",
+    "            \"description\": \"This is a parameter\",\n",
+    "            \"value\": 0.0,\n",
+    "            \"validators\": {\n",
+    "                \"range\": {\n",
+    "                    \"min\": 0.0,\n",
+    "                    \"max\": 1.0\n",
+    "                }\n",
+    "            }\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "### Some examples of large parameter files:\n",
+    "\n",
+    "1. [Tax-Calculator](https://github.com/PSLmodels/Tax-Calculator/blob/master/taxcalc/policy_current_law.json) current law policy parameters\n",
+    "2. [Cost-of-Capital-Calculator](http://ccc.pslmodels.org/content/intro.html), a) [current law defaults for tax rates and other non-asset-specific parameters](https://github.com/PSLmodels/Cost-of-Capital-Calculator/blob/master/ccc/default_parameters.json), b) [asset-specific depreciation parameters](https://github.com/PSLmodels/Cost-of-Capital-Calculator/blob/master/ccc/tax_depreciation_rules.json)\n",
+    "3. [OG-Core](https://github.com/PSLmodels/OG-Core/blob/master/ogcore/default_parameters.json) default parameters\n",
+    "\n",
+    "This format of the JSON file, with meta data together with values, makes it easy to generate documentation of the model parameter.  E.g., [Tax-Calculator parameters](https://taxcalc.pslmodels.org/guide/policy_params.html), [OG-PSL parameters](https://eapd-drb.github.io/OG-PHL/content/calibration/exogenous_parameters.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Passing Parameters within a model\n",
+    "\n",
+    "`ParamTools` allows us to create a parameters class object that can be passed around within a model.  This object can be used to store parameter values, metadata, and other information. \n",
+    "\n",
+    "This becomes extremely useful when we have a large model with many parameters that need to be passed around to different, often deeply nested, function calls.\n",
+    "\n",
+    "The OG-Core model has good examples of this, e.g., in the [module that solves the model's steady-state](https://github.com/PSLmodels/OG-Core/blob/master/ogcore/SS.py)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "3. Updating Parameters\n",
+    "\n",
+    "`ParamTools` allows us to update parameters in a systematic way.  We can update parameters by passing a dictionary of new values (or a JSON of new values) to the `adjust` method of the ParamTools `Parameters` object (Note, this method is sometimes renamed in different implementations, e.g., in the Tax-Calculator model it is named `implement_reform`, but retains the same basic functionality).  This method will update the parameter values and validate the new values against the parameter constraints.\n",
+    "\n",
+    "An example from the Tax-Calculator model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top marginal IIT rate in 2026 under current law is 0.396\n"
+     ]
+    }
+   ],
+   "source": [
+    "from taxcalc import Policy\n",
+    "pol = Policy()\n",
+    "# view the top tax rate in 2026 under current law\n",
+    "pol.set_year(2026)\n",
+    "print(f\"Top marginal IIT rate in 2026 under current law is {pol.II_rt7[0]}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top marginal IIT rate in 2026 under TCJA extension would be 0.37\n"
+     ]
+    }
+   ],
+   "source": [
+    "# update from current law policy, to full TCJA extension\n",
+    "json_url = 'https://raw.githubusercontent.com/PSLmodels/Tax-Calculator/master/taxcalc/reforms/ext.json'\n",
+    "pol.implement_reform(taxcalc.Policy.read_json_reform(json_url))\n",
+    "# view the top tax rate in 2026 under TCJA extension\n",
+    "pol.set_year(2026)\n",
+    "print(f\"Top marginal IIT rate in 2026 under TCJA extension would be {pol.II_rt7[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An example from the set of [OG-Core](https://github.com/PSLmodels/OG-Core)-related models:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 110,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Debt to GDP in 2024 in the USA is 0.99\n",
+      "Debt to GDP in 2024 in ZAF is 0.74\n",
+      "The corporate income tax rate in 2024 in the USA is 0.21\n",
+      "The corporate income tax rate in 2024 in ZAF is 0.27\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "# Load the default parameters for OG model\n",
+    "og_params = ogcore.parameters.Specifications()\n",
+    "# Update to USA\n",
+    "# copy params\n",
+    "usa_params = copy.deepcopy(og_params)\n",
+    "usa_url = 'https://raw.githubusercontent.com/PSLmodels/OG-USA/master/ogusa/ogusa_default_parameters.json'\n",
+    "usa_params.update_specifications(usa_url)\n",
+    "# Update to PHL\n",
+    "# copy params\n",
+    "zaf_params = copy.deepcopy(og_params)\n",
+    "zaf_url = 'https://raw.githubusercontent.com/EAPD-DRB/OG-ZAF/refs/heads/main/ogzaf/ogzaf_default_parameters.json'\n",
+    "zaf_params.update_specifications(zaf_url)\n",
+    "\n",
+    "print(f\"Debt to GDP in 2024 in the USA is {usa_params.initial_debt_ratio}\")\n",
+    "print(f\"Debt to GDP in 2024 in ZAF is {zaf_params.initial_debt_ratio}\")\n",
+    "\n",
+    "print(f\"The corporate income tax rate in 2024 in the USA is {usa_params.cit_rate[0][0]}\")\n",
+    "print(f\"The corporate income tax rate in 2024 in ZAF is {zaf_params.cit_rate[0][0]}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Parameter validation\n",
+    "\n",
+    "`ParamTools` allows us to validate parameters.  When we update parameters, the `adjust` method will validate the new values against the parameter validators.  If the new values do not meet the constraints, the method will raise an error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 111,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValidationError",
+     "evalue": "{\n    \"errors\": {\n        \"cit_rate\": [\n            \"cit_rate [[1.5]] > max 0.99 \"\n        ]\n    }\n}",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValidationError\u001b[0m                           Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[111], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# Example of setting a float value outside of the range\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[43musa_params\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mupdate_specifications\u001b[49m\u001b[43m(\u001b[49m\u001b[43m{\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mcit_rate\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[43m[\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m1.5\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m]\u001b[49m\u001b[43m}\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/anaconda3/envs/usitc-env/lib/python3.12/site-packages/ogcore/parameters.py:451\u001b[0m, in \u001b[0;36mSpecifications.update_specifications\u001b[0;34m(self, revision, raise_errors)\u001b[0m\n\u001b[1;32m    449\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m (\u001b[38;5;167;01mKeyError\u001b[39;00m, \u001b[38;5;167;01mTypeError\u001b[39;00m):\n\u001b[1;32m    450\u001b[0m         \u001b[38;5;28;01mpass\u001b[39;00m\n\u001b[0;32m--> 451\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43madjust\u001b[49m\u001b[43m(\u001b[49m\u001b[43mrevision\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mraise_errors\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mraise_errors\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    452\u001b[0m \u001b[38;5;66;03m# put tax values skipped over in the adjust method back in so\u001b[39;00m\n\u001b[1;32m    453\u001b[0m \u001b[38;5;66;03m# they are in the parameters class.\u001b[39;00m\n\u001b[1;32m    454\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m tax_update_dict \u001b[38;5;241m!=\u001b[39m {}:\n",
+      "File \u001b[0;32m~/anaconda3/envs/usitc-env/lib/python3.12/site-packages/paramtools/parameters.py:257\u001b[0m, in \u001b[0;36mParameters.adjust\u001b[0;34m(self, params_or_path, ignore_warnings, raise_errors, extend_adj, clobber)\u001b[0m\n\u001b[1;32m    210\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21madjust\u001b[39m(\n\u001b[1;32m    211\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m    212\u001b[0m     params_or_path: Union[\u001b[38;5;28mstr\u001b[39m, Mapping[\u001b[38;5;28mstr\u001b[39m, List[ValueObject]]],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    216\u001b[0m     clobber: \u001b[38;5;28mbool\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m,\n\u001b[1;32m    217\u001b[0m ):\n\u001b[1;32m    218\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    219\u001b[0m \u001b[38;5;124;03m    Deserialize and validate parameter adjustments. `params_or_path`\u001b[39;00m\n\u001b[1;32m    220\u001b[0m \u001b[38;5;124;03m    can be a file path or a `dict` that has not been fully deserialized.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    255\u001b[0m \u001b[38;5;124;03m        least one existing value item's corresponding label values.\u001b[39;00m\n\u001b[1;32m    256\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 257\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_adjust\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    258\u001b[0m \u001b[43m        \u001b[49m\u001b[43mparams_or_path\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    259\u001b[0m \u001b[43m        \u001b[49m\u001b[43mignore_warnings\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mignore_warnings\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    260\u001b[0m \u001b[43m        \u001b[49m\u001b[43mraise_errors\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mraise_errors\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    261\u001b[0m \u001b[43m        \u001b[49m\u001b[43mextend_adj\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mextend_adj\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    262\u001b[0m \u001b[43m        \u001b[49m\u001b[43mclobber\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mclobber\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    263\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/anaconda3/envs/usitc-env/lib/python3.12/site-packages/paramtools/parameters.py:375\u001b[0m, in \u001b[0;36mParameters._adjust\u001b[0;34m(self, params_or_path, ignore_warnings, raise_errors, extend_adj, deserialized, validate, clobber)\u001b[0m\n\u001b[1;32m    371\u001b[0m \u001b[38;5;66;03m# throw error if raise_errors is True or ignore_warnings is False\u001b[39;00m\n\u001b[1;32m    372\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m (raise_errors \u001b[38;5;129;01mand\u001b[39;00m has_errors) \u001b[38;5;129;01mor\u001b[39;00m (\n\u001b[1;32m    373\u001b[0m     \u001b[38;5;129;01mnot\u001b[39;00m ignore_warnings \u001b[38;5;129;01mand\u001b[39;00m has_warnings\n\u001b[1;32m    374\u001b[0m ):\n\u001b[0;32m--> 375\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvalidation_error\n\u001b[1;32m    377\u001b[0m \u001b[38;5;66;03m# Update attrs for params that were adjusted.\u001b[39;00m\n\u001b[1;32m    378\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_set_state(params\u001b[38;5;241m=\u001b[39mparsed_params\u001b[38;5;241m.\u001b[39mkeys())\n",
+      "\u001b[0;31mValidationError\u001b[0m: {\n    \"errors\": {\n        \"cit_rate\": [\n            \"cit_rate [[1.5]] > max 0.99 \"\n        ]\n    }\n}"
+     ]
+    }
+   ],
+   "source": [
+    "# Example of setting a float value outside of the range\n",
+    "usa_params.update_specifications({'cit_rate': [[1.5]]})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValidationError",
+     "evalue": "{\n    \"errors\": {\n        \"tax_func_type\": [\n            \"tax_func_type \\\"whatever\\\" must be in list of choices DEP, DEP_totalinc, GS, HSV, linear, mono, mono2D.\"\n        ]\n    }\n}",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValidationError\u001b[0m                           Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[112], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[38;5;66;03m# Example of setting a string outside a list of acceptable values\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m \u001b[43musa_params\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mupdate_specifications\u001b[49m\u001b[43m(\u001b[49m\u001b[43m{\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mtax_func_type\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mwhatever\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m}\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/anaconda3/envs/usitc-env/lib/python3.12/site-packages/ogcore/parameters.py:451\u001b[0m, in \u001b[0;36mSpecifications.update_specifications\u001b[0;34m(self, revision, raise_errors)\u001b[0m\n\u001b[1;32m    449\u001b[0m     \u001b[38;5;28;01mexcept\u001b[39;00m (\u001b[38;5;167;01mKeyError\u001b[39;00m, \u001b[38;5;167;01mTypeError\u001b[39;00m):\n\u001b[1;32m    450\u001b[0m         \u001b[38;5;28;01mpass\u001b[39;00m\n\u001b[0;32m--> 451\u001b[0m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43madjust\u001b[49m\u001b[43m(\u001b[49m\u001b[43mrevision\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mraise_errors\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mraise_errors\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    452\u001b[0m \u001b[38;5;66;03m# put tax values skipped over in the adjust method back in so\u001b[39;00m\n\u001b[1;32m    453\u001b[0m \u001b[38;5;66;03m# they are in the parameters class.\u001b[39;00m\n\u001b[1;32m    454\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m tax_update_dict \u001b[38;5;241m!=\u001b[39m {}:\n",
+      "File \u001b[0;32m~/anaconda3/envs/usitc-env/lib/python3.12/site-packages/paramtools/parameters.py:257\u001b[0m, in \u001b[0;36mParameters.adjust\u001b[0;34m(self, params_or_path, ignore_warnings, raise_errors, extend_adj, clobber)\u001b[0m\n\u001b[1;32m    210\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21madjust\u001b[39m(\n\u001b[1;32m    211\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m    212\u001b[0m     params_or_path: Union[\u001b[38;5;28mstr\u001b[39m, Mapping[\u001b[38;5;28mstr\u001b[39m, List[ValueObject]]],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    216\u001b[0m     clobber: \u001b[38;5;28mbool\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mTrue\u001b[39;00m,\n\u001b[1;32m    217\u001b[0m ):\n\u001b[1;32m    218\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    219\u001b[0m \u001b[38;5;124;03m    Deserialize and validate parameter adjustments. `params_or_path`\u001b[39;00m\n\u001b[1;32m    220\u001b[0m \u001b[38;5;124;03m    can be a file path or a `dict` that has not been fully deserialized.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    255\u001b[0m \u001b[38;5;124;03m        least one existing value item's corresponding label values.\u001b[39;00m\n\u001b[1;32m    256\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 257\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_adjust\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    258\u001b[0m \u001b[43m        \u001b[49m\u001b[43mparams_or_path\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    259\u001b[0m \u001b[43m        \u001b[49m\u001b[43mignore_warnings\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mignore_warnings\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    260\u001b[0m \u001b[43m        \u001b[49m\u001b[43mraise_errors\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mraise_errors\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    261\u001b[0m \u001b[43m        \u001b[49m\u001b[43mextend_adj\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mextend_adj\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    262\u001b[0m \u001b[43m        \u001b[49m\u001b[43mclobber\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mclobber\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    263\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/anaconda3/envs/usitc-env/lib/python3.12/site-packages/paramtools/parameters.py:375\u001b[0m, in \u001b[0;36mParameters._adjust\u001b[0;34m(self, params_or_path, ignore_warnings, raise_errors, extend_adj, deserialized, validate, clobber)\u001b[0m\n\u001b[1;32m    371\u001b[0m \u001b[38;5;66;03m# throw error if raise_errors is True or ignore_warnings is False\u001b[39;00m\n\u001b[1;32m    372\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m (raise_errors \u001b[38;5;129;01mand\u001b[39;00m has_errors) \u001b[38;5;129;01mor\u001b[39;00m (\n\u001b[1;32m    373\u001b[0m     \u001b[38;5;129;01mnot\u001b[39;00m ignore_warnings \u001b[38;5;129;01mand\u001b[39;00m has_warnings\n\u001b[1;32m    374\u001b[0m ):\n\u001b[0;32m--> 375\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mvalidation_error\n\u001b[1;32m    377\u001b[0m \u001b[38;5;66;03m# Update attrs for params that were adjusted.\u001b[39;00m\n\u001b[1;32m    378\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_set_state(params\u001b[38;5;241m=\u001b[39mparsed_params\u001b[38;5;241m.\u001b[39mkeys())\n",
+      "\u001b[0;31mValidationError\u001b[0m: {\n    \"errors\": {\n        \"tax_func_type\": [\n            \"tax_func_type \\\"whatever\\\" must be in list of choices DEP, DEP_totalinc, GS, HSV, linear, mono, mono2D.\"\n        ]\n    }\n}"
+     ]
+    }
+   ],
+   "source": [
+    "# Example of setting a string outside a list of acceptable values\n",
+    "usa_params.update_specifications({'tax_func_type': \"whatever\"})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Time varying and indexed parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define a custom TaxParams class that extends the built-in Parameters class.\n",
+    "class TaxParams(paramtools.Parameters):\n",
+    "    defaults = {\n",
+    "        \"schema\": {\n",
+    "            \"labels\": {\n",
+    "                \"year\": {\n",
+    "                    \"type\": \"int\",\n",
+    "                    \"validators\": {\"range\": {\"min\": 2013, \"max\": 2033}}\n",
+    "                },\n",
+    "                \"marital_status\": {\n",
+    "                    \"type\": \"str\",\n",
+    "                    \"validators\": {\"choice\": {\"choices\": [\"single\", \"joint\"]}}\n",
+    "                },\n",
+    "            }\n",
+    "        },\n",
+    "        \"standard_deduction\": {\n",
+    "            \"title\": \"Standard deduction amount\",\n",
+    "            \"description\": \"Amount filing unit can use as a standard deduction.\",\n",
+    "            \"type\": \"float\",\n",
+    "\n",
+    "            # Set indexed to True to extend standard_deduction with the built-in\n",
+    "            # extension logic.\n",
+    "            \"indexed\": True,\n",
+    "            \"value\": [\n",
+    "                {\"year\": 2013, \"marital_status\": \"single\", \"value\": 6100.0},\n",
+    "                {\"year\": 2013, \"marital_status\": \"joint\", \"value\": 12200.0},\n",
+    "                {\"year\": 2018, \"marital_status\": \"single\", \"value\": 12000},\n",
+    "                {\"year\": 2018, \"marital_status\": \"joint\", \"value\": 24000},\n",
+    "                {\"year\": 2026, \"marital_status\": \"single\", \"value\": 7685},\n",
+    "                {\"year\": 2026, \"marital_status\": \"joint\", \"value\": 15369}],\n",
+    "            \"validators\": {\n",
+    "                \"range\": {\n",
+    "                    \"min\": 0,\n",
+    "                    \"max\": 9e+99\n",
+    "                }\n",
+    "            }\n",
+    "        },\n",
+    "    }\n",
+    "    array_first = True\n",
+    "    label_to_extend = \"year\"\n",
+    "    # Activate use of extend_func method.\n",
+    "    uses_extend_func = True\n",
+    "    # inflation rates from Tax-Calculator v4.3.0\n",
+    "    index_rates = {\n",
+    "        2013: 0.0148,\n",
+    "        2014: 0.0159,\n",
+    "        2015: 0.0012,\n",
+    "        2016: 0.0126,\n",
+    "        2017: 0.0167,\n",
+    "        2018: 0.02,\n",
+    "        2019: 0.013,\n",
+    "        2020: 0.008,\n",
+    "        2021: 0.0427,\n",
+    "        2022: 0.0723,\n",
+    "        2023: 0.054,\n",
+    "        2024: 0.055,\n",
+    "        2025: 0.0212,\n",
+    "        2026: 0.0207,\n",
+    "        2027: 0.0195,\n",
+    "        2028: 0.0194,\n",
+    "        2029: 0.0197,\n",
+    "        2030: 0.0198,\n",
+    "        2031: 0.0199,\n",
+    "        2032: 0.020,\n",
+    "        2033: 0.020\n",
+    "    }"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[ 6100.  , 12200.  ],\n",
+       "       [ 6190.28, 12380.56],\n",
+       "       [ 6288.71, 12577.41],\n",
+       "       [ 6296.26, 12592.5 ],\n",
+       "       [ 6375.59, 12751.17],\n",
+       "       [12000.  , 24000.  ],\n",
+       "       [12240.  , 24480.  ],\n",
+       "       [12399.12, 24798.24],\n",
+       "       [12498.31, 24996.63],\n",
+       "       [13031.99, 26063.99],\n",
+       "       [13974.2 , 27948.42],\n",
+       "       [14728.81, 29457.63],\n",
+       "       [15538.89, 31077.8 ],\n",
+       "       [ 7685.  , 15369.  ],\n",
+       "       [ 7844.08, 15687.14],\n",
+       "       [ 7997.04, 15993.04],\n",
+       "       [ 8152.18, 16303.3 ],\n",
+       "       [ 8312.78, 16624.48],\n",
+       "       [ 8477.37, 16953.64],\n",
+       "       [ 8646.07, 17291.02],\n",
+       "       [ 8818.99, 17636.84]])"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "params = TaxParams()\n",
+    "params.standard_deduction"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Values([\n",
+       "  {'value': 6100.0, 'year': 2013, 'marital_status': 'single'},\n",
+       "  {'value': 12200.0, 'year': 2013, 'marital_status': 'joint'},\n",
+       "  {'value': 12000.0, 'year': 2018, 'marital_status': 'single'},\n",
+       "  {'value': 24000.0, 'year': 2018, 'marital_status': 'joint'},\n",
+       "  {'value': 7685.0, 'year': 2026, 'marital_status': 'single'},\n",
+       "  {'value': 15369.0, 'year': 2026, 'marital_status': 'joint'},\n",
+       "  {'value': 6190.28, 'year': 2014, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 6288.71, 'year': 2015, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 6296.26, 'year': 2016, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 6375.59, 'year': 2017, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 12240.0, 'year': 2019, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 12399.12, 'year': 2020, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 12498.31, 'year': 2021, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 13031.99, 'year': 2022, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 13974.2, 'year': 2023, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 14728.81, 'year': 2024, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 15538.89, 'year': 2025, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 7844.08, 'year': 2027, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 7997.04, 'year': 2028, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 8152.18, 'year': 2029, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 8312.78, 'year': 2030, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 8477.37, 'year': 2031, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 8646.07, 'year': 2032, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 8818.99, 'year': 2033, 'marital_status': 'single', '_auto': True},\n",
+       "  {'value': 12380.56, 'year': 2014, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 12577.41, 'year': 2015, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 12592.5, 'year': 2016, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 12751.17, 'year': 2017, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 24480.0, 'year': 2019, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 24798.24, 'year': 2020, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 24996.63, 'year': 2021, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 26063.99, 'year': 2022, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 27948.42, 'year': 2023, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 29457.63, 'year': 2024, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 31077.8, 'year': 2025, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 15687.14, 'year': 2027, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 15993.04, 'year': 2028, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 16303.3, 'year': 2029, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 16624.48, 'year': 2030, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 16953.64, 'year': 2031, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 17291.02, 'year': 2032, 'marital_status': 'joint', '_auto': True},\n",
+       "  {'value': 17636.84, 'year': 2033, 'marital_status': 'joint', '_auto': True},\n",
+       "])"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Or show as list of dicts\n",
+    "params.sel[\"standard_deduction\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "usitc-env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/environment.yml
+++ b/environment.yml
@@ -38,3 +38,6 @@ dependencies:
   - plotly-express
   - pyreadstat
   - tables
+  - paramtools
+  - taxcalc
+  - ogcore


### PR DESCRIPTION
This PR adds a notebook illustrating the ParamTools package, as well as updates the `environment.yml` to includes `paramtools`, and two packages used as examples, `taxcalc`, and `ogcore`.

